### PR TITLE
Update to BSD 2-clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright 2019-2021 by Aquinas Hobor, Shengyi Wang, Qinxiang Cao, and Anshuman
-Mohan.
+Copyright (c) 2019-2021 by Aquinas Hobor, Shengyi Wang, Qinxiang Cao, and
+Anshuman Mohan. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,24 @@
-1.  The Verified Software Toolchain (VST) project is the work of 
-Andrew W. Appel, Lennart Beringer, Robert Dockins, Josiah Dodds, 
-Aquinas Hobor, Gordon Stewart, and Qinxiang Cao, and others. 
-It is copyright and licensed according to the terms in "VST/LICENSE".
-
-2.  The CertiGraph project is copyright 2019 by Aquinas Hobor, 
-Shengyi Wang, Qinxiang Cao, and Anshuman Mohan, and is open-source 
-licensed as follows:
+Copyright 2019-2021 by Aquinas Hobor, Shengyi Wang, Qinxiang Cao, and Anshuman
+Mohan.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-- Redistribution of source code must retain the above copyright notice,
+1. Redistributions of source code must retain the above copyright notice,
 this list of conditions and the following disclaimer.
 
-- Redistribution in binary form must reproduce the above copyright notice,
+2. Redistributions in binary form must reproduce the above copyright notice,
 this list of conditions and the following disclaimer in the documentation
 and/or other materials provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR THE CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Powered by [Coq](https://coq.inria.fr) and [VST](https://vst.cs.princeton.edu/).
 
 * Aquinas Hobor
 * Shengyi Wang
+* Qinxiang Cao
 * Anshuman Mohan
 
 


### PR DESCRIPTION
# tl;dr

Closes #3 

Linked issue mentioned MIT license (a fine choice) but the existing license appears to be BSD 2-clause. As far as I know these licenses are practically equivalent, so (following the principle of least change) this PR sticks with BSD 2-clause.

