### PR TITLE
Draft Demo SumTree

### DIFF
--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,0 +1,19 @@
+all: Makefile.coq
+	+make -f Makefile.coq all
+
+clean: Makefile.coq
+	+make -f Makefile.coq clean
+	rm -f Makefile.coq
+	rm -f Makefile.coq.conf
+	rm -f website/*html
+
+Makefile.coq: _CoqProject
+	coq_makefile -f _CoqProject -o Makefile.coq
+
+
+website: Makefile.coq
+	+make -f Makefile.coq html
+	rm -rf html
+
+.PHONY: all clean website
+

--- a/demo/Verif_treeread.v
+++ b/demo/Verif_treeread.v
@@ -1,0 +1,264 @@
+(** * Demo: Traversing Imperative Structures *) 
+
+(** A brief demo on how to use the CertiGraph library.
+
+Consider the following C program: 
+
+<<
+#include <stdlib.h>
+
+/* demonstrate traversal of a read-only tree */
+
+struct tree {
+  unsigned int n;
+  struct tree *left, *right;
+};
+
+
+unsigned int sum (struct tree *t) {
+  if (t==NULL)
+    return 0;
+  else return t->n + sum(t->left) + sum (t->right);
+}
+>>
+
+*) 
+
+Require Import VST.floyd.proofauto.
+Require Import VST.msl.iter_sepcon.
+Require Import TR.treeread.
+
+Instance CompSpecs : compspecs. make_compspecs prog. Defined.
+Definition Vprog : varspecs. mk_varspecs prog. Defined.
+
+Definition t_struct_tree := Tstruct _tree noattr.
+
+(** The Coq representation of a tree is a nested tuple of three values. *) 
+Compute (reptype t_struct_tree). 
+
+(** ** The Functional Model 
+
+Our functional model contains
+-  a data structure of trees, where a tree is either a leaf [E] or a binary node [T n tl tr] with a label [n], left subtree [tl], and right subtree [tr]
+- the function [sum] which adds up all labels in a tree.
+ *) 
+Inductive tree : Type :=
+ | E: tree
+ | T: int -> tree -> tree -> tree.
+
+Fixpoint sum (t : tree) : int :=
+  match t with
+  | E => Int.zero
+  | T n tl tr => Int.add n (Int.add (sum tl) (sum tr))
+  end.
+
+
+(** ** Simplified model
+
+  We start with a simplified model which highlights the general localization tactics.
+*) 
+
+Module SimplifiedModel.
+
+(** In this simplified model, a graph is a list of the addresses and representations of trees. *) 
+Definition graph := list (val * reptype t_struct_tree).
+
+(** A graph representation separates all trees. *)
+Definition graph_rep (g: graph) : mpred :=
+  iter_sepcon (fun p => data_at Ews t_struct_tree (snd p) (fst p)) g.
+
+(** An inductive predicate stating that a tree is present in a graph.
+    Note that this is a purely propositional predicate.
+ *) 
+Inductive tree_in_graph (g: graph) : tree -> val -> Prop :=
+| TIG_E: tree_in_graph g E nullval (** The empty tree corresponds to the null value. *) 
+| TIG_T: (** Definition of a leaf *)
+    forall (p : val) (n : int) tl (pl : val) tr (pr: val),
+    In (p, (Vint n, (pl, pr))) g ->
+    tree_in_graph g tl pl ->
+    tree_in_graph g tr pr ->
+    tree_in_graph g (T n tl tr) p.
+
+(** The VST specification of [sum] contains of a spatial and a propositional part: 
+ - In the spatial part, we declare the spatial graph representation of [g].
+ - In the propositional part, we state that graph [g] contains a representation of tree [t] at position [p].
+*) 
+Definition sum_spec :=
+ DECLARE _sum
+ WITH g: graph, t: tree, p: val
+  PRE  [ tptr t_struct_tree ]
+       PROP(tree_in_graph g t p)
+       PARAMS (p)
+       SEP (graph_rep g)
+  POST [ tuint ]
+    PROP()
+    LOCAL(temp ret_temp (Vint (sum t)))
+    SEP (graph_rep g).
+
+Definition Gprog : funspecs := [ sum_spec ]. 
+
+(** We require several intermediate facts, which will later be provided automatically by the CertiGraph library. *)  
+
+(** Predicate needed for the localization *) 
+Lemma graph_rep_In (g : graph) (n: reptype t_struct_tree) p: 
+  In (p, n) g -> graph_rep g = (data_at Ews t_struct_tree n p * (data_at Ews t_struct_tree n p -* graph_rep g))%logic. 
+Proof.
+  intros. apply pred_ext. 
+  - induction g; simpl in *. 
+    + inversion H. 
+    + destruct H as [|]; subst.
+      * simpl. entailer!. apply wand_sepcon_adjoint. entailer!. 
+      * specialize (IHg H). sep_apply IHg. entailer. cancel.
+        rewrite <- wand_sepcon_adjoint.
+        cancel. rewrite sepcon_comm. apply modus_ponens_wand. 
+  - sep_apply modus_ponens_wand. entailer.
+Qed.
+
+(** We will require local facts for  [tree_in_graph]. *)
+
+Lemma graph_rep_In_valid p v g: 
+  In (p, v) g -> graph_rep g |-- valid_pointer p. 
+Proof.
+  intros H. rewrite (graph_rep_In _ _ _ H). entailer!.
+Qed.
+ 
+Lemma valid_pointer_tree g t p: 
+tree_in_graph g t p -> graph_rep g |-- valid_pointer p. 
+Proof. 
+  induction 1. 
+  - entailer!. 
+  - entailer!. eauto using graph_rep_In_valid.
+Qed.
+
+Hint Resolve valid_pointer_tree : valid_pointer.
+
+Lemma graph_rep_local_facts p v g: 
+  In (p, v) g -> graph_rep g |-- !!(isptr p). 
+Proof.
+  intros H. rewrite (graph_rep_In _ _ _ H). entailer!.
+Qed.
+
+Lemma treerep_local_facts g: 
+graph_rep g |-- !!(forall t p, tree_in_graph g t p ->  is_pointer_or_null p). 
+Proof.
+  rewrite prop_forall. apply allp_right. intros t.
+  rewrite prop_forall. apply allp_right. intros v. 
+  rewrite prop_impl. apply imp_andp_adjoint. entailer.
+  induction H.
+   - entailer!.
+   - entailer. sep_apply (graph_rep_local_facts p (Vint n, (pl, pr))). entailer!. 
+Qed.
+
+Hint Resolve treerep_local_facts : saturate_local.
+
+(** Inversion predicates for tree representations *)
+Lemma tree_in_graph_null g t:
+  tree_in_graph g t nullval -> graph_rep g |-- !!(t = E). 
+Proof.
+  intros H. 
+  inversion H; subst.
+  - entailer!.
+  - sep_apply (graph_rep_In _ _ _ H0). entailer!.
+Qed.
+
+Lemma tree_in_graph_nonnull: forall g t p,
+  p <> nullval -> tree_in_graph g t p ->
+  graph_rep g |--
+    EX pl pr: val, EX n : int, EX tl tr : tree,
+      graph_rep g && !! (In (p, (Vint n, (pl, pr))) g /\ t = T n tl tr /\ tree_in_graph g tl pl /\ tree_in_graph g tr pr). 
+Proof.
+  intros. inversion H0; subst. 
+  - congruence. 
+  - Exists pl pr n tl tr. entailer!. 
+Qed.
+
+
+(** *** The main theorem *) 
+Lemma body_sum: semax_body Vprog Gprog f_sum sum_spec.
+Proof.
+  start_function.
+  forward_if. 
+  { sep_apply (valid_pointer_tree _ _ _ H). entailer!. }
+  - subst. sep_apply (tree_in_graph_null _ _ H). 
+    forward.
+  - sep_apply (tree_in_graph_nonnull _ _ _ H0 H).  
+    Intros pl pr n tl tr. subst. 
+
+    assert_PROP (is_pointer_or_null pl). { entailer!. eauto. }
+    assert_PROP (is_pointer_or_null pr). { entailer!. eauto. }
+    
+    (** Here, the localization tactic is used to single out the representation of one node. *)                                    
+    localize [data_at Ews t_struct_tree (Vint n, (pl, pr)) p].
+    (* unfold abbreviate in RamL. 
+    unfold abbreviate in RamG. *)
+    forward.
+    (** We can undo the localization. *) 
+    unlocalize [graph_rep g].
+    { rewrite <- graph_rep_In; auto. } 
+
+    forward_call (g, tl, pl). 
+
+    localize [data_at Ews t_struct_tree (Vint n, (pl, pr)) p]. 
+    forward.
+    unlocalize [graph_rep g].
+    { rewrite <- graph_rep_In; auto. } 
+
+    forward_call (g, tr, pr). 
+
+    localize [data_at Ews t_struct_tree (Vint n, (pl, pr)) p]. 
+    forward.
+    unlocalize [graph_rep g].
+    { rewrite <- graph_rep_In; auto. } 
+
+    forward. entailer!.
+    now rewrite Int.add_assoc.
+Qed.
+
+End SimplifiedModel.
+
+
+
+(** ** Part 2: In CertiGraph *) 
+
+Require Import CertiGraph. (* TODO *) 
+
+Definition graph : Type := (* TODO *).
+
+Inductive tree_in_graph (g: graph) : tree -> val -> Prop :=
+| TIG_E: tree_in_graph g E nullval (** The empty tree corresponds to the null value. *) 
+| TIG_T: (** Definition of a leaf *)
+    forall (p : val) (n : int) tl (pl : val) tr (pr: val),
+(*     graph_has_v (p, (Vint n, (pl, pr))) g ->
+       replace with a suitable predicate.
+ *)
+    tree_in_graph g tl pl ->
+    tree_in_graph g tr pr ->
+    tree_in_graph g (T n tl tr) p.
+
+
+(** An inductive predicate corresponding to ... *) 
+
+Definition sum_spec :=
+ DECLARE _sum
+ WITH g: graph, t: tree, p: val, sh: wshare, x : addr
+  PRE  [ tptr t_struct_tree ]
+       PROP(tree_in_graph g t p)
+       PARAMS (p)
+       SEP (graph_rep sh x g)
+       (* The term "g" has type "graph" while it is expected to have type "LabeledGraph addr (addr * LR) bool unit unit". *) 
+  POST [ tuint ]
+    PROP()
+    LOCAL(temp ret_temp (Vint (sum t)))
+    SEP (graph_rep g).
+
+
+Lemma body_sum: semax_body Vprog Gprog f_sum sum_spec.
+Proof.
+ (* TODO *) 
+Admitted.
+
+
+(** Related Work: 
+
+
+*) 

--- a/demo/_CoqProject
+++ b/demo/_CoqProject
@@ -1,0 +1,4 @@
+-Q . TR
+
+treeread.v
+Verif_treeread.v

--- a/demo/treeread.c
+++ b/demo/treeread.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+
+/* demonstrate traversal of a read-only tree */
+
+struct tree {
+  unsigned int n;
+  struct tree *left, *right;
+};
+
+
+unsigned int sum (struct tree *t) {
+  if (t==NULL)
+    return 0;
+  else return t->n + sum(t->left) + sum (t->right);
+}

--- a/demo/treeread.v
+++ b/demo/treeread.v
@@ -1,0 +1,427 @@
+From Coq Require Import String List ZArith.
+From compcert Require Import Coqlib Integers Floats AST Ctypes Cop Clight Clightdefs.
+Import Clightdefs.ClightNotations.
+Local Open Scope Z_scope.
+Local Open Scope string_scope.
+Local Open Scope clight_scope.
+
+Module Info.
+  Definition version := "3.9".
+  Definition build_number := "".
+  Definition build_tag := "".
+  Definition build_branch := "".
+  Definition arch := "x86".
+  Definition model := "64".
+  Definition abi := "macos".
+  Definition bitsize := 64.
+  Definition big_endian := false.
+  Definition source_file := "treeread.c".
+  Definition normalized := true.
+End Info.
+
+Definition ___builtin_annot : ident := 21%positive.
+Definition ___builtin_annot_intval : ident := 22%positive.
+Definition ___builtin_bswap : ident := 6%positive.
+Definition ___builtin_bswap16 : ident := 8%positive.
+Definition ___builtin_bswap32 : ident := 7%positive.
+Definition ___builtin_bswap64 : ident := 5%positive.
+Definition ___builtin_clz : ident := 9%positive.
+Definition ___builtin_clzl : ident := 10%positive.
+Definition ___builtin_clzll : ident := 11%positive.
+Definition ___builtin_ctz : ident := 12%positive.
+Definition ___builtin_ctzl : ident := 13%positive.
+Definition ___builtin_ctzll : ident := 14%positive.
+Definition ___builtin_debug : ident := 59%positive.
+Definition ___builtin_expect : ident := 33%positive.
+Definition ___builtin_fabs : ident := 15%positive.
+Definition ___builtin_fabsf : ident := 16%positive.
+Definition ___builtin_fmadd : ident := 51%positive.
+Definition ___builtin_fmax : ident := 49%positive.
+Definition ___builtin_fmin : ident := 50%positive.
+Definition ___builtin_fmsub : ident := 52%positive.
+Definition ___builtin_fnmadd : ident := 53%positive.
+Definition ___builtin_fnmsub : ident := 54%positive.
+Definition ___builtin_fsqrt : ident := 17%positive.
+Definition ___builtin_membar : ident := 23%positive.
+Definition ___builtin_memcpy_aligned : ident := 19%positive.
+Definition ___builtin_read16_reversed : ident := 55%positive.
+Definition ___builtin_read32_reversed : ident := 56%positive.
+Definition ___builtin_sel : ident := 20%positive.
+Definition ___builtin_sqrt : ident := 18%positive.
+Definition ___builtin_unreachable : ident := 32%positive.
+Definition ___builtin_va_arg : ident := 25%positive.
+Definition ___builtin_va_copy : ident := 26%positive.
+Definition ___builtin_va_end : ident := 27%positive.
+Definition ___builtin_va_start : ident := 24%positive.
+Definition ___builtin_write16_reversed : ident := 57%positive.
+Definition ___builtin_write32_reversed : ident := 58%positive.
+Definition ___compcert_i64_dtos : ident := 34%positive.
+Definition ___compcert_i64_dtou : ident := 35%positive.
+Definition ___compcert_i64_sar : ident := 46%positive.
+Definition ___compcert_i64_sdiv : ident := 40%positive.
+Definition ___compcert_i64_shl : ident := 44%positive.
+Definition ___compcert_i64_shr : ident := 45%positive.
+Definition ___compcert_i64_smod : ident := 42%positive.
+Definition ___compcert_i64_smulh : ident := 47%positive.
+Definition ___compcert_i64_stod : ident := 36%positive.
+Definition ___compcert_i64_stof : ident := 38%positive.
+Definition ___compcert_i64_udiv : ident := 41%positive.
+Definition ___compcert_i64_umod : ident := 43%positive.
+Definition ___compcert_i64_umulh : ident := 48%positive.
+Definition ___compcert_i64_utod : ident := 37%positive.
+Definition ___compcert_i64_utof : ident := 39%positive.
+Definition ___compcert_va_composite : ident := 31%positive.
+Definition ___compcert_va_float64 : ident := 30%positive.
+Definition ___compcert_va_int32 : ident := 28%positive.
+Definition ___compcert_va_int64 : ident := 29%positive.
+Definition _left : ident := 3%positive.
+Definition _main : ident := 62%positive.
+Definition _n : ident := 1%positive.
+Definition _right : ident := 4%positive.
+Definition _sum : ident := 61%positive.
+Definition _t : ident := 60%positive.
+Definition _tree : ident := 2%positive.
+Definition _t'1 : ident := 63%positive.
+Definition _t'2 : ident := 64%positive.
+Definition _t'3 : ident := 65%positive.
+Definition _t'4 : ident := 66%positive.
+Definition _t'5 : ident := 67%positive.
+
+Definition f_sum := {|
+  fn_return := tuint;
+  fn_callconv := cc_default;
+  fn_params := ((_t, (tptr (Tstruct _tree noattr))) :: nil);
+  fn_vars := nil;
+  fn_temps := ((_t'2, tuint) :: (_t'1, tuint) ::
+               (_t'5, (tptr (Tstruct _tree noattr))) ::
+               (_t'4, (tptr (Tstruct _tree noattr))) :: (_t'3, tuint) :: nil);
+  fn_body :=
+(Sifthenelse (Ebinop Oeq (Etempvar _t (tptr (Tstruct _tree noattr)))
+               (Ecast (Econst_int (Int.repr 0) tint) (tptr tvoid)) tint)
+  (Sreturn (Some (Econst_int (Int.repr 0) tint)))
+  (Ssequence
+    (Ssequence
+      (Ssequence
+        (Sset _t'5
+          (Efield
+            (Ederef (Etempvar _t (tptr (Tstruct _tree noattr)))
+              (Tstruct _tree noattr)) _left (tptr (Tstruct _tree noattr))))
+        (Scall (Some _t'1)
+          (Evar _sum (Tfunction (Tcons (tptr (Tstruct _tree noattr)) Tnil)
+                       tuint cc_default))
+          ((Etempvar _t'5 (tptr (Tstruct _tree noattr))) :: nil)))
+      (Ssequence
+        (Sset _t'4
+          (Efield
+            (Ederef (Etempvar _t (tptr (Tstruct _tree noattr)))
+              (Tstruct _tree noattr)) _right (tptr (Tstruct _tree noattr))))
+        (Scall (Some _t'2)
+          (Evar _sum (Tfunction (Tcons (tptr (Tstruct _tree noattr)) Tnil)
+                       tuint cc_default))
+          ((Etempvar _t'4 (tptr (Tstruct _tree noattr))) :: nil))))
+    (Ssequence
+      (Sset _t'3
+        (Efield
+          (Ederef (Etempvar _t (tptr (Tstruct _tree noattr)))
+            (Tstruct _tree noattr)) _n tuint))
+      (Sreturn (Some (Ebinop Oadd
+                       (Ebinop Oadd (Etempvar _t'3 tuint)
+                         (Etempvar _t'1 tuint) tuint) (Etempvar _t'2 tuint)
+                       tuint))))))
+|}.
+
+Definition composites : list composite_definition :=
+(Composite _tree Struct
+   ((_n, tuint) :: (_left, (tptr (Tstruct _tree noattr))) ::
+    (_right, (tptr (Tstruct _tree noattr))) :: nil)
+   noattr :: nil).
+
+Definition global_definitions : list (ident * globdef fundef type) :=
+((___builtin_bswap64,
+   Gfun(External (EF_builtin "__builtin_bswap64"
+                   (mksignature (AST.Tlong :: nil) AST.Tlong cc_default))
+     (Tcons tulong Tnil) tulong cc_default)) ::
+ (___builtin_bswap,
+   Gfun(External (EF_builtin "__builtin_bswap"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap32,
+   Gfun(External (EF_builtin "__builtin_bswap32"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tuint cc_default)) ::
+ (___builtin_bswap16,
+   Gfun(External (EF_builtin "__builtin_bswap16"
+                   (mksignature (AST.Tint :: nil) AST.Tint16unsigned
+                     cc_default)) (Tcons tushort Tnil) tushort cc_default)) ::
+ (___builtin_clz,
+   Gfun(External (EF_builtin "__builtin_clz"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_clzl,
+   Gfun(External (EF_builtin "__builtin_clzl"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_clzll,
+   Gfun(External (EF_builtin "__builtin_clzll"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_ctz,
+   Gfun(External (EF_builtin "__builtin_ctz"
+                   (mksignature (AST.Tint :: nil) AST.Tint cc_default))
+     (Tcons tuint Tnil) tint cc_default)) ::
+ (___builtin_ctzl,
+   Gfun(External (EF_builtin "__builtin_ctzl"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_ctzll,
+   Gfun(External (EF_builtin "__builtin_ctzll"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons tulong Tnil) tint cc_default)) ::
+ (___builtin_fabs,
+   Gfun(External (EF_builtin "__builtin_fabs"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_fabsf,
+   Gfun(External (EF_builtin "__builtin_fabsf"
+                   (mksignature (AST.Tsingle :: nil) AST.Tsingle cc_default))
+     (Tcons tfloat Tnil) tfloat cc_default)) ::
+ (___builtin_fsqrt,
+   Gfun(External (EF_builtin "__builtin_fsqrt"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_sqrt,
+   Gfun(External (EF_builtin "__builtin_sqrt"
+                   (mksignature (AST.Tfloat :: nil) AST.Tfloat cc_default))
+     (Tcons tdouble Tnil) tdouble cc_default)) ::
+ (___builtin_memcpy_aligned,
+   Gfun(External (EF_builtin "__builtin_memcpy_aligned"
+                   (mksignature
+                     (AST.Tlong :: AST.Tlong :: AST.Tlong :: AST.Tlong ::
+                      nil) AST.Tvoid cc_default))
+     (Tcons (tptr tvoid)
+       (Tcons (tptr tvoid) (Tcons tulong (Tcons tulong Tnil)))) tvoid
+     cc_default)) ::
+ (___builtin_sel,
+   Gfun(External (EF_builtin "__builtin_sel"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tbool Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot,
+   Gfun(External (EF_builtin "__builtin_annot"
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons (tptr tschar) Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (___builtin_annot_intval,
+   Gfun(External (EF_builtin "__builtin_annot_intval"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tint
+                     cc_default)) (Tcons (tptr tschar) (Tcons tint Tnil))
+     tint cc_default)) ::
+ (___builtin_membar,
+   Gfun(External (EF_builtin "__builtin_membar"
+                   (mksignature nil AST.Tvoid cc_default)) Tnil tvoid
+     cc_default)) ::
+ (___builtin_va_start,
+   Gfun(External (EF_builtin "__builtin_va_start"
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___builtin_va_arg,
+   Gfun(External (EF_builtin "__builtin_va_arg"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_va_copy,
+   Gfun(External (EF_builtin "__builtin_va_copy"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tvoid
+                     cc_default))
+     (Tcons (tptr tvoid) (Tcons (tptr tvoid) Tnil)) tvoid cc_default)) ::
+ (___builtin_va_end,
+   Gfun(External (EF_builtin "__builtin_va_end"
+                   (mksignature (AST.Tlong :: nil) AST.Tvoid cc_default))
+     (Tcons (tptr tvoid) Tnil) tvoid cc_default)) ::
+ (___compcert_va_int32,
+   Gfun(External (EF_external "__compcert_va_int32"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons (tptr tvoid) Tnil) tuint cc_default)) ::
+ (___compcert_va_int64,
+   Gfun(External (EF_external "__compcert_va_int64"
+                   (mksignature (AST.Tlong :: nil) AST.Tlong cc_default))
+     (Tcons (tptr tvoid) Tnil) tulong cc_default)) ::
+ (___compcert_va_float64,
+   Gfun(External (EF_external "__compcert_va_float64"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons (tptr tvoid) Tnil) tdouble cc_default)) ::
+ (___compcert_va_composite,
+   Gfun(External (EF_external "__compcert_va_composite"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons (tptr tvoid) (Tcons tulong Tnil))
+     (tptr tvoid) cc_default)) ::
+ (___builtin_unreachable,
+   Gfun(External (EF_builtin "__builtin_unreachable"
+                   (mksignature nil AST.Tvoid cc_default)) Tnil tvoid
+     cc_default)) ::
+ (___builtin_expect,
+   Gfun(External (EF_builtin "__builtin_expect"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_dtos,
+   Gfun(External (EF_runtime "__compcert_i64_dtos"
+                   (mksignature (AST.Tfloat :: nil) AST.Tlong cc_default))
+     (Tcons tdouble Tnil) tlong cc_default)) ::
+ (___compcert_i64_dtou,
+   Gfun(External (EF_runtime "__compcert_i64_dtou"
+                   (mksignature (AST.Tfloat :: nil) AST.Tlong cc_default))
+     (Tcons tdouble Tnil) tulong cc_default)) ::
+ (___compcert_i64_stod,
+   Gfun(External (EF_runtime "__compcert_i64_stod"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons tlong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_utod,
+   Gfun(External (EF_runtime "__compcert_i64_utod"
+                   (mksignature (AST.Tlong :: nil) AST.Tfloat cc_default))
+     (Tcons tulong Tnil) tdouble cc_default)) ::
+ (___compcert_i64_stof,
+   Gfun(External (EF_runtime "__compcert_i64_stof"
+                   (mksignature (AST.Tlong :: nil) AST.Tsingle cc_default))
+     (Tcons tlong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_utof,
+   Gfun(External (EF_runtime "__compcert_i64_utof"
+                   (mksignature (AST.Tlong :: nil) AST.Tsingle cc_default))
+     (Tcons tulong Tnil) tfloat cc_default)) ::
+ (___compcert_i64_sdiv,
+   Gfun(External (EF_runtime "__compcert_i64_sdiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_udiv,
+   Gfun(External (EF_runtime "__compcert_i64_udiv"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_smod,
+   Gfun(External (EF_runtime "__compcert_i64_smod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_umod,
+   Gfun(External (EF_runtime "__compcert_i64_umod"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_shl,
+   Gfun(External (EF_runtime "__compcert_i64_shl"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tint Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_shr,
+   Gfun(External (EF_runtime "__compcert_i64_shr"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tint Tnil)) tulong
+     cc_default)) ::
+ (___compcert_i64_sar,
+   Gfun(External (EF_runtime "__compcert_i64_sar"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tint Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_smulh,
+   Gfun(External (EF_runtime "__compcert_i64_smulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tlong (Tcons tlong Tnil)) tlong
+     cc_default)) ::
+ (___compcert_i64_umulh,
+   Gfun(External (EF_runtime "__compcert_i64_umulh"
+                   (mksignature (AST.Tlong :: AST.Tlong :: nil) AST.Tlong
+                     cc_default)) (Tcons tulong (Tcons tulong Tnil)) tulong
+     cc_default)) ::
+ (___builtin_fmax,
+   Gfun(External (EF_builtin "__builtin_fmax"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil) AST.Tfloat
+                     cc_default)) (Tcons tdouble (Tcons tdouble Tnil))
+     tdouble cc_default)) ::
+ (___builtin_fmin,
+   Gfun(External (EF_builtin "__builtin_fmin"
+                   (mksignature (AST.Tfloat :: AST.Tfloat :: nil) AST.Tfloat
+                     cc_default)) (Tcons tdouble (Tcons tdouble Tnil))
+     tdouble cc_default)) ::
+ (___builtin_fmadd,
+   Gfun(External (EF_builtin "__builtin_fmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fmsub,
+   Gfun(External (EF_builtin "__builtin_fmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmadd,
+   Gfun(External (EF_builtin "__builtin_fnmadd"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_fnmsub,
+   Gfun(External (EF_builtin "__builtin_fnmsub"
+                   (mksignature
+                     (AST.Tfloat :: AST.Tfloat :: AST.Tfloat :: nil)
+                     AST.Tfloat cc_default))
+     (Tcons tdouble (Tcons tdouble (Tcons tdouble Tnil))) tdouble
+     cc_default)) ::
+ (___builtin_read16_reversed,
+   Gfun(External (EF_builtin "__builtin_read16_reversed"
+                   (mksignature (AST.Tlong :: nil) AST.Tint16unsigned
+                     cc_default)) (Tcons (tptr tushort) Tnil) tushort
+     cc_default)) ::
+ (___builtin_read32_reversed,
+   Gfun(External (EF_builtin "__builtin_read32_reversed"
+                   (mksignature (AST.Tlong :: nil) AST.Tint cc_default))
+     (Tcons (tptr tuint) Tnil) tuint cc_default)) ::
+ (___builtin_write16_reversed,
+   Gfun(External (EF_builtin "__builtin_write16_reversed"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tushort) (Tcons tushort Tnil))
+     tvoid cc_default)) ::
+ (___builtin_write32_reversed,
+   Gfun(External (EF_builtin "__builtin_write32_reversed"
+                   (mksignature (AST.Tlong :: AST.Tint :: nil) AST.Tvoid
+                     cc_default)) (Tcons (tptr tuint) (Tcons tuint Tnil))
+     tvoid cc_default)) ::
+ (___builtin_debug,
+   Gfun(External (EF_external "__builtin_debug"
+                   (mksignature (AST.Tint :: nil) AST.Tvoid
+                     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|}))
+     (Tcons tint Tnil) tvoid
+     {|cc_vararg:=(Some 1); cc_unproto:=false; cc_structret:=false|})) ::
+ (_sum, Gfun(Internal f_sum)) :: nil).
+
+Definition public_idents : list ident :=
+(_sum :: ___builtin_debug :: ___builtin_write32_reversed ::
+ ___builtin_write16_reversed :: ___builtin_read32_reversed ::
+ ___builtin_read16_reversed :: ___builtin_fnmsub :: ___builtin_fnmadd ::
+ ___builtin_fmsub :: ___builtin_fmadd :: ___builtin_fmin ::
+ ___builtin_fmax :: ___compcert_i64_umulh :: ___compcert_i64_smulh ::
+ ___compcert_i64_sar :: ___compcert_i64_shr :: ___compcert_i64_shl ::
+ ___compcert_i64_umod :: ___compcert_i64_smod :: ___compcert_i64_udiv ::
+ ___compcert_i64_sdiv :: ___compcert_i64_utof :: ___compcert_i64_stof ::
+ ___compcert_i64_utod :: ___compcert_i64_stod :: ___compcert_i64_dtou ::
+ ___compcert_i64_dtos :: ___builtin_expect :: ___builtin_unreachable ::
+ ___compcert_va_composite :: ___compcert_va_float64 ::
+ ___compcert_va_int64 :: ___compcert_va_int32 :: ___builtin_va_end ::
+ ___builtin_va_copy :: ___builtin_va_arg :: ___builtin_va_start ::
+ ___builtin_membar :: ___builtin_annot_intval :: ___builtin_annot ::
+ ___builtin_sel :: ___builtin_memcpy_aligned :: ___builtin_sqrt ::
+ ___builtin_fsqrt :: ___builtin_fabsf :: ___builtin_fabs ::
+ ___builtin_ctzll :: ___builtin_ctzl :: ___builtin_ctz :: ___builtin_clzll ::
+ ___builtin_clzl :: ___builtin_clz :: ___builtin_bswap16 ::
+ ___builtin_bswap32 :: ___builtin_bswap :: ___builtin_bswap64 :: nil).
+
+Definition prog : Clight.program := 
+  mkprogram composites global_definitions public_idents _main Logic.I.
+
+


### PR DESCRIPTION
Hi all! 

Andrew suggested to provide a demo with the CertiGraph repo and proposed the very small demo we developed at the beginning of 2020 for our VeriFFI could be suitable for this. 
The demo (attached, in a draft version with comments) doesn’t use the CertiGraph library, but afaik the same principles in a simplified version.
Before I build out the comments, it would be useful to know whether this could be useful for you at all.

One idea for a possible CertiGraph demo could be to split it into two parts: 

- The simplified representation, where many proofs have to be done fully manually. Still, the main principles could be explained (and be made explicit).
- A full representation, repeating the same proof with the more elaborate graph model of CertiGraph and using library lemmas.
  As far as I see, the only things to be changed are the definition of a graph/the definition of graph_rep/sum_spec using the new definitions/the adapted proof of body_sum.

What do you think about the suitability of such a demo?
If this demo could be useful, I could use a hint  on which exact version of graphs best to use (for the VeriFFI, I previously mainly used the more complex graphs corresponding to CertiCoq which are an overkill here).
Maybe there’s even the exact proof I want already in the repo, and I just don’t know? 

Best, 
Kathrin