### PR TITLE
Add support for Coq 8.14 (and also add GitHub actions to test the build)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: build
+
+on:
+  push:
+    branches:
+      - live  # forall push/merge in live
+  pull_request:
+    branches:
+      - "**"  # forall submitted Pull Requests
+  workflow_dispatch:
+    inputs:
+
+runs-on: ubuntu-latest
+strategy:
+  # See https://github.com/coq-community/docker-coq/wiki#supported-tags
+  matrix:
+    ocaml_version:
+      - '4.11-flambda'
+    coq_version:
+      - '8.13'
+      - '8.14'
+      # - latest
+      # - dev
+    opam_file:
+      - 'coq-certigraph.opam'
+      - 'coq-certigraph-32.opam'
+  fail-fast: false  # don't stop jobs if one fails
+steps:
+  - uses: actions/checkout@v2
+  - uses: coq-community/docker-coq-action@v1
+    with:
+      opam_file: ${{ matrix.opam_file }}
+      coq_version: ${{ matrix.coq_version }}
+      ocaml_version: ${{ matrix.ocaml_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,25 +10,27 @@ on:
   workflow_dispatch:
     inputs:
 
-runs-on: ubuntu-latest
-strategy:
-  # See https://github.com/coq-community/docker-coq/wiki#supported-tags
-  matrix:
-    ocaml_version:
-      - '4.11-flambda'
-    coq_version:
-      - '8.13'
-      - '8.14'
-      # - latest
-      # - dev
-    opam_file:
-      - 'coq-certigraph.opam'
-      - 'coq-certigraph-32.opam'
-  fail-fast: false  # don't stop jobs if one fails
-steps:
-  - uses: actions/checkout@v2
-  - uses: coq-community/docker-coq-action@v1
-    with:
-      opam_file: ${{ matrix.opam_file }}
-      coq_version: ${{ matrix.coq_version }}
-      ocaml_version: ${{ matrix.ocaml_version }}
+jobs:
+  build-matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      # See https://github.com/coq-community/docker-coq/wiki#supported-tags
+      matrix:
+        ocaml_version:
+          - '4.11-flambda'
+        coq_version:
+          - '8.13'
+          - '8.14'
+          # - latest
+          # - dev
+        opam_file:
+          - 'coq-certigraph.opam'
+          - 'coq-certigraph-32.opam'
+      fail-fast: false  # don't stop jobs if one fails
+    steps:
+      - uses: actions/checkout@v2
+      - uses: coq-community/docker-coq-action@v1
+        with:
+          opam_file: ${{ matrix.opam_file }}
+          coq_version: ${{ matrix.coq_version }}
+          ocaml_version: ${{ matrix.ocaml_version }}

--- a/binheap/binary_heap_model.v
+++ b/binheap/binary_heap_model.v
@@ -774,7 +774,9 @@ Proof.
               rewrite <- H4 in *. destruct H. transitivity a; eapply H.
               2: apply H0. lia. trivial. 2: apply H5. lia. trivial.
     - rewrite hOhO2. repeat intro. destruct (eq_nat_dec i j).
-      subst j. rewrite H1 in H3. rewrite H0 in H4. inversion H3. inversion H4. subst a0 a1. clear H3 H4.
+      subst j.
+      assert (E: a0 = b) by congruence. subst.
+      assert (E: a1 = a) by congruence. subst.
       destruct (Aleq_linear a b); auto. contradiction.
       destruct H.
       apply H with i; auto.


### PR DESCRIPTION
This PR includes two updates:

1. The example `binheap/binary_heap_model.v` has been updated to build in Coq 8.14. The build was broken because the name of an automatically-named hypothesis changed for whatever reason. I fixed the issue by rewriting that section of the proof to omit explicit references to any of the hypotheses. I have tested this build with Coq 8.14 and `BITSIZE=64`, but have not yet tested any of the other targets (Coq 8.13, or BITSIZE=32). However ...
2. I have also added a GitHub action (`.github/workflows/build.yml`) that leverages [docker-coq-action](https://github.com/coq-community/docker-coq-action) to test CertiGraph builds with various versions of Coq and various `BITSIZE` settings. A similar example can be found in [VST](https://github.com/PrincetonUniversity/VST/blob/master/.github/workflows/coq-action.yml). This action is configured to test both `opam` files in both Coq 8.13 and 8.14.

Unfortunately, AFAIK there is no way to test a GitHub action without actually merging it into `live`. However, I am hopeful that this action will automatically trigger builds on the following events:
* Pushing to `live`
* Submitting a pull request
* Manual invocation from the [Actions](https://github.com/Salamari/CertiGraph/actions) menu

If this PR is accepted and we merge into `live`, then we can use the GitHub action to test the full build matrix.