### PR TITLE
Switched to using custom docker images for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image:
-          - 'tcarstens/coq-vst:8.14.1-ocaml-4.12.0-flambda--compcert-3.9--vst-2.8'
-          - 'tcarstens/coq-vst:8.13.2-ocaml-4.11.2-flambda--compcert-3.9--vst-2.8'
         opam_file:
           - 'coq-certigraph.opam'
           - 'coq-certigraph-32.opam'
+        image:
+          - 'tcarstens/coq-vst:8.14.1-ocaml-4.12.0-flambda--compcert-3.9--vst-2.8'
+          - 'tcarstens/coq-vst:8.13.2-ocaml-4.11.2-flambda--compcert-3.9--vst-2.8'
       fail-fast: false  # don't stop jobs if one fails
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,10 @@ jobs:
   build-matrix:
     runs-on: ubuntu-latest
     strategy:
-      # See https://github.com/coq-community/docker-coq/wiki#supported-tags
       matrix:
-        ocaml_version:
-          - '4.11-flambda'
-        coq_version:
-          - '8.13'
-          - '8.14'
-          # - latest
-          # - dev
+        image:
+          - 'tcarstens/coq-vst:8.14.1-ocaml-4.12.0-flambda--compcert-3.9--vst-2.8'
+          - 'tcarstens/coq-vst:8.13.2-ocaml-4.11.2-flambda--compcert-3.9--vst-2.8'
         opam_file:
           - 'coq-certigraph.opam'
           - 'coq-certigraph-32.opam'
@@ -31,6 +26,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: coq-community/docker-coq-action@v1
         with:
+          custom_image: ${{ matrix.image }}
           opam_file: ${{ matrix.opam_file }}
-          coq_version: ${{ matrix.coq_version }}
-          ocaml_version: ${{ matrix.ocaml_version }}


### PR DESCRIPTION
In #14, I added CI steps based on [docker-coq-action](https://github.com/coq-community/docker-coq-action). This worked great, with one minor exception: it takes a long time to run. The issue is that the default `docker` image does not contain `compcert` or `vst`, which means the CI must fetch and install these packages every time it runs.

To address this, I've put together some docker images that contain `compcert` and `vst`. This PR updates CertiGraph to use those images, which should cut down on CI runtime significantly.

# About the images

The images are defined in [docker-coq-vst](https://github.com/appliedfm/docker-coq-vst/). Indeed, that repo actually defines two docker images: one containing compcert and VST, the other containing compcert, VST, and CertiGraph 😇

The image definitions are only half the story. The other half is the image builds, which are hosted [by my personal docker account](https://hub.docker.com/r/tcarstens/coq-vst/tags). This PR refers to the images hosted there. (I hope to find a better place to host these images long-term.)